### PR TITLE
修复转换中路径被直接传入 exec 的问题

### DIFF
--- a/lib/message/ptt.js
+++ b/lib/message/ptt.js
@@ -139,7 +139,7 @@ async function makePttElem(target, cq) {
  */
 function _audioTrans(cache_file, tmp_file) {
     return new Promise((resolve, reject) => {
-        exec(`ffmpeg -y -i ${tmp_file} -ac 1 -ar 8000 -f amr ${cache_file}`, async (error, stdout, stderr) => {
+        exec(`ffmpeg -y -i "${tmp_file}" -ac 1 -ar 8000 -f amr "${cache_file}"`, async (error, stdout, stderr) => {
             this.logger.debug("ffmpeg output: " + stdout + stderr);
             try {
                 const amr = await fs.promises.readFile(cache_file);
@@ -271,7 +271,7 @@ async function makeVideoElem(target, file) {
     file = file.replace(/^file:\/{2,3}/, "");
     const thumb = path.join(this.dir, "../image", common.uuid());
     await new Promise((resolve, reject) => {
-        exec(`ffmpeg -y -i ${file} -f image2 -frames:v 1 ${thumb}`, (error, stdout, stderr) => {
+        exec(`ffmpeg -y -i "${file}" -f image2 -frames:v 1 "${thumb}"`, (error, stdout, stderr) => {
             this.logger.debug("ffmpeg output: " + stdout + stderr);
             fs.stat(thumb, (err) => {
                 if (err) reject(ERROR_FFMPEG_IMAGE2_FAILED);
@@ -280,7 +280,7 @@ async function makeVideoElem(target, file) {
         });
     });
     const [width, height, seconds] = await new Promise((resolve) => {
-        exec(`ffprobe -i ${file} -show_streams`, (error, stdout, stderr) => {
+        exec(`ffprobe -i "${file}" -show_streams`, (error, stdout, stderr) => {
             this.logger.debug("ffmpeg output: " + stdout + stderr);
             const lines = (stdout || stderr || "").split("\n");
             let width = 1280, height = 720, seconds = 120;


### PR DESCRIPTION
exec 执行中路径文件路径没有被正确转义。例如，当路径中含有空格时，exec 就极有可能执行异常。

在 exec 对文件路径的引用中加入双引号可以缓解这一问题。（直接转义文件路径也许更好）

此解决方法在 GNU/Linux 上测试成功，Windows 应该也可以用。