### PR TITLE
修复 macOS 被识别成 Windows

### DIFF
--- a/lib/common.ts
+++ b/lib/common.ts
@@ -134,7 +134,7 @@ export class DownloadTransform extends stream.Transform {
 }
 
 export const PB_CONTENT = pb.encode({ 1: 1, 2: 0, 3: 0 })
-export const IS_WIN = os.platform().includes("win")
+export const IS_WIN = os.platform() === "win32"
 
 /** 系统临时目录，用于临时存放下载的图片等内容 */
 export const TMP_DIR = os.tmpdir()


### PR DESCRIPTION
<!--
- 新API和事件的添加务必事先达成共识(包括命名、参数、分类等)
- 若需引入新依赖，务必事先达成共识
- 务必检查自己的代码是否与周围画风不同
- 代码规范基本遵循以下规则：
  * 缩进使用tab，行末不写分号(必须要写请写在下一行的开头)
  * 类型用大驼峰，function型用小驼峰，常量用大写+下划线，其他用小写+下划线，文件名全小写
-->
macOS 的内核叫做 `darwin`，`'darwin'.includes('win')`，所以不能这么判断

应该直接 `os.platform === 'win32'`