### PR TITLE
fix: 私聊回复消息产生一个多余的@

### DIFF
--- a/lib/message/converter.ts
+++ b/lib/message/converter.ts
@@ -444,8 +444,6 @@ export class Converter {
 	quote(source: Quotable) {
 		const elems = new Converter(source.message || "", this.ext).elems
 		const tmp = this.brief
-		this.at({ type: "at", qq: source.user_id })
-		this.elems.unshift(this.elems.pop()!)
 		this.elems.unshift({
 			45: {
 				1: [source.seq],

--- a/lib/message/converter.ts
+++ b/lib/message/converter.ts
@@ -444,6 +444,10 @@ export class Converter {
 	quote(source: Quotable) {
 		const elems = new Converter(source.message || "", this.ext).elems
 		const tmp = this.brief
+		if(!this.ext?.dm){
+			this.at({ type: "at", qq: source.user_id })
+			this.elems.unshift(this.elems.pop()!)
+		}
 		this.elems.unshift({
 			45: {
 				1: [source.seq],


### PR DESCRIPTION
<!--
- 新API和事件的添加务必事先达成共识(包括命名、参数、分类等)
- 若需引入新依赖，务必事先达成共识
- 务必检查自己的代码是否与周围画风不同
- 代码规范基本遵循以下规则：
  * 缩进使用tab，行末不写分号(必须要写请写在下一行的开头)
  * 类型用大驼峰，function型用小驼峰，常量用大写+下划线，其他用小写+下划线，文件名全小写
-->

在私聊时，用 quote 回复别人的消息会产生一个多余的 @，消息看起来像这样

```
@1234567890消息内容
```