### PR TITLE
Bug无法@全体人员

### DIFF
--- a/lib/message/elements.ts
+++ b/lib/message/elements.ts
@@ -228,7 +228,7 @@ export const segment = {
 	 * @param qq 全体成员:"all", 频道:tiny_id
 	 */
 	at(qq: number | string, text?: string, dummy?: boolean): AtElem {
-		if (Number(qq) <= 0xffffffff || qq === "all") {
+		if (Number(qq) <= 0xffffffff) {
 			return {
 				type: "at", qq: Number(qq), text, dummy
 			}


### PR DESCRIPTION
if(Number(qq) <= 0xffffffff || qq === "all" )为true 
qq="all"  Number(qq)=NaN  无法@全体

<!--
- 新API和事件的添加务必事先达成共识(包括命名、参数、分类等)
- 若需引入新依赖，务必事先达成共识
- 务必检查自己的代码是否与周围画风不同
- 代码规范基本遵循以下规则：
  * 缩进使用tab，行末不写分号(必须要写请写在下一行的开头)
  * 类型用大驼峰，function型用小驼峰，常量用大写+下划线，其他用小写+下划线，文件名全小写
-->
