### PR TITLE
fix: 合并转发消息使用群聊模式会导致部分框架无法解析来源

### DIFF
--- a/lib/internal/contactable.ts
+++ b/lib/internal/contactable.ts
@@ -445,7 +445,7 @@ export abstract class Contactable {
 						1: this.target,
 						4: nickname,
 					},
-					14: nickname,
+					14: this.dm ? nickname : null,
 					20: {
 						1: 0,
 						2: rand


### PR DESCRIPTION
<!--
- 新API和事件的添加务必事先达成共识(包括命名、参数、分类等)
- 若需引入新依赖，务必事先达成共识
- 务必检查自己的代码是否与周围画风不同
- 代码规范基本遵循以下规则：
  * 缩进使用tab，行末不写分号(必须要写请写在下一行的开头)
  * 类型用大驼峰，function型用小驼峰，常量用大写+下划线，其他用小写+下划线，文件名全小写
-->
原版 QQ 合并转发群消息时，[1][14] 中实际上无数据，nickname 只存储在 [1][9][4] 中。 
而 oicq 发送的合并转发消息两处都存放有 nickname，由于部分框架解析时的逻辑问题，这会导致其在解析消息时误认为无来源或来自私聊消息，例如 oicq v1 的 /lib/message/parser.js 中的 
```javascript
        if (head[14]) {
            nickname = String(head[14]);
        } else {
            try {
                nickname = String(head[9][4]);
                group_id = head[9][1];
            } catch { }
        }
```
当 head[14] 和 head[9][4] 同时存在时，将无法返回 head[9][1] 中的 group_id。 