### PR TITLE
修复不能全局at的bug

### DIFF
--- a/lib/message/elements.ts
+++ b/lib/message/elements.ts
@@ -230,7 +230,7 @@ export const segment = {
 	at(qq: number | string, text?: string, dummy?: boolean): AtElem {
 		if (Number(qq) <= 0xffffffff || qq === "all") {
 			return {
-				type: "at", qq: Number(qq), text, dummy
+				type: "at", qq: qq === "all" ? "all" : Number(qq), text, dummy
 			}
 		}
 		// 频道中的AT
@@ -334,7 +334,7 @@ function unescapeCQInside(s: string) {
 	return ""
 }
 function qs(s: string, sep = ",", equal = "=") {
-	const ret: any = { }
+	const ret: any = {}
 	const split = s.split(sep)
 	for (let v of split) {
 		const i = v.indexOf(equal)

--- a/lib/message/elements.ts
+++ b/lib/message/elements.ts
@@ -334,7 +334,7 @@ function unescapeCQInside(s: string) {
 	return ""
 }
 function qs(s: string, sep = ",", equal = "=") {
-	const ret: any = {}
+	const ret: any = { }
 	const split = s.split(sep)
 	for (let v of split) {
 		const i = v.indexOf(equal)


### PR DESCRIPTION
<!--
- 新API和事件的添加务必事先达成共识(包括命名、参数、分类等)
- 若需引入新依赖，务必事先达成共识
- 务必检查自己的代码是否与周围画风不同
- 代码规范基本遵循以下规则：
  * 缩进使用tab，行末不写分号(必须要写请写在下一行的开头)
  * 类型用大驼峰，function型用小驼峰，常量用大写+下划线，其他用小写+下划线，文件名全小写
-->
修复at全体成员时qq号被转换成NaN的bug