### PR TITLE
修复node类型缺失问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "probe-image-size": "^7.2.2"
   },
   "devDependencies": {
-    "@types/node": "^16.7.2",
+    "@types/node": "^17.0.38",
     "@types/pngjs": "^6.0.1",
     "@types/probe-image-size": "^7.0.1",
     "@types/ws": "^8.2.0",


### PR DESCRIPTION
* 添加了@type/node

<!--
- 新API和事件的添加务必事先达成共识(包括命名、参数、分类等)
- 若需引入新依赖，务必事先达成共识
- 务必检查自己的代码是否与周围画风不同
- 代码规范基本遵循以下规则：
  * 缩进使用tab，行末不写分号(必须要写请写在下一行的开头)
  * 类型用大驼峰，function型用小驼峰，常量用大写+下划线，其他用小写+下划线，文件名全小写
-->

使用Buffer（多次出现）等名字的时候会出现Warning
