### PR TITLE
feat: Support nested MultiMsg

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -311,8 +311,8 @@ export class Client extends BaseClient {
 		return this.pickFriend(this.uin).getVideoUrl(fid, md5)
 	}
 	/** 获取转发消息 */
-	getForwardMsg(resid: string) {
-		return this.pickFriend(this.uin).getForwardMsg(resid)
+	getForwardMsg(resid: string, fileName?: string) {
+		return this.pickFriend(this.uin).getForwardMsg(resid, fileName)
 	}
 	/** 制作转发消息 */
 	makeForwardMsg(fake: Forwardable[], dm = false) {

--- a/lib/internal/contactable.ts
+++ b/lib/internal/contactable.ts
@@ -480,11 +480,21 @@ export abstract class Contactable {
 	}
 
 	/** 下载并解析合并转发 */
-	async getForwardMsg(resid: string) {
+	async getForwardMsg(resid: string, fileName: string = "MultiMsg") {
 		const ret = []
 		const buf = await this._downloadMultiMsg(String(resid), 2)
 		let a = pb.decode(buf)[2]
-		if (Array.isArray(a)) a = a[0]
+		if (!Array.isArray(a)) a = [a]
+		let m_default = a[0]
+		for (let b of a) {
+			const m_fileName = b[1].toString()
+			if (m_fileName === fileName) {
+				a = b
+				m_default = null
+				break
+			}
+		}
+		if (fileName === "MultiMsg" && m_default) a = m_default
 		a = a[2][1]
 		if (!Array.isArray(a)) a = [a]
 		for (let proto of a) {

--- a/lib/internal/contactable.ts
+++ b/lib/internal/contactable.ts
@@ -485,16 +485,14 @@ export abstract class Contactable {
 		const buf = await this._downloadMultiMsg(String(resid), 2)
 		let a = pb.decode(buf)[2]
 		if (!Array.isArray(a)) a = [a]
-		let m_default = a[0]
 		for (let b of a) {
 			const m_fileName = b[1].toString()
 			if (m_fileName === fileName) {
 				a = b
-				m_default = null
 				break
 			}
 		}
-		if (fileName === "MultiMsg" && m_default) a = m_default
+		if (Array.isArray(a)) a = a[0]
 		a = a[2][1]
 		if (!Array.isArray(a)) a = [a]
 		for (let proto of a) {


### PR DESCRIPTION
如#265 中的描述，通过 `getForwardMsg(resid)` API 解析嵌套合并消息，只会返回第一条合并消息内容。
经测试，某些情况下（如获取 PCQQ 生成的嵌套合并转发），此 API 返回的消息甚至有可能不是最外层转发消息。
这个 PR 可以在不改变 `getForwardMsg` 返回数据结构，只增加可选参数的情况下支持获取嵌套转发。
fileName 为嵌套转发中子转发的 m_fileName，默认获取最外层转发为 `MultiMsg`，调用 API 时根据 fileName 即可获取对应的子转发消息集合。