### PR TITLE
fix: 修复 data_dir 相对路径的错误处理

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -646,7 +646,7 @@ function createDataDir(dir: string, uin: number) {
 		fs.mkdirSync(img_path)
 	if (!fs.existsSync(uin_path))
 		fs.mkdirSync(uin_path, { mode: 0o755 })
-	return uin_path
+	return path.isAbsolute(uin_path) ? uin_path : path.join(process.cwd(), uin_path)
 }
 
 /** 创建一个客户端 (=new Client) */


### PR DESCRIPTION
data_dir 为相对路径时会导致 device 重复生成，修改 createDataDir 统一返回绝对路径