### PR TITLE
修复 MacOS 协议提示版本过低的错误 #408

### DIFF
--- a/lib/core/device.ts
+++ b/lib/core/device.ts
@@ -158,7 +158,7 @@ const apklist: {[platform in Platform]: Apk} = {
 	[Platform.iPad]: { ...hd },
 }
 
-apklist[Platform.iMac].subid = 537064315
+apklist[Platform.iMac].subid = 537128930
 apklist[Platform.iMac].display = "iMac"
 apklist[Platform.iPad].subid = 537118796
 apklist[Platform.iPad].display = "iPad"


### PR DESCRIPTION
最近有 MacOS 登录错误，QQ 在 2022.08.25 发布的 v6.8.2 QQ Mac版使用了新的 subid。

subid 解包自 QQ_6.8.2.21241_966_EXP.dmg

在本机测试通过。