### PR TITLE
修复 mobileQQ 协议提示版本过低的错误 #451

### DIFF
--- a/lib/core/device.ts
+++ b/lib/core/device.ts
@@ -109,13 +109,13 @@ export type Apk = typeof mobile
 
 const mobile = {
 	id: "com.tencent.mobileqq",
-	name: "A8.8.80.7400",
-	version: "8.8.80.7400",
-	ver: "8.8.80",
+	name: "A8.9.15.9425",
+	version: "8.9.15.9425",
+	ver: "8.9.15",
 	sign: Buffer.from([166, 183, 69, 191, 36, 162, 194, 119, 82, 119, 22, 246, 243, 110, 182, 141]),
 	buildtime: 1640921786,
 	appid: 16,
-	subid: 537113159,
+	subid: 537138832,
 	bitmap: 184024956,
 	sigmap: 34869472,
 	sdkver: "6.0.0.2494",


### PR DESCRIPTION
偶然遇到 mobile 登录时提示 QQ 版本过低 #451 ，更新subid后自测可用