### PR TITLE
fix:群对象创建时Client未缓存群员列表，可能导致pickMember函数失效

### DIFF
--- a/lib/group.ts
+++ b/lib/group.ts
@@ -90,6 +90,8 @@ export class Group extends Discuss {
 		let group = weakmap.get(info!)
 		if (group) return group
 		group = new Group(this, Number(gid), info)
+		// 将群员列表缓存进Client的gml
+		group._fetchMembers()
 		if (info)
 			weakmap.set(info, group)
 		return group


### PR DESCRIPTION
<!--
- 新API和事件的添加务必事先达成共识(包括命名、参数、分类等)
- 若需引入新依赖，务必事先达成共识
- 务必检查自己的代码是否与周围画风不同
- 代码规范基本遵循以下规则：
  * 缩进使用tab，行末不写分号(必须要写请写在下一行的开头)
  * 类型用大驼峰，function型用小驼峰，常量用大写+下划线，其他用小写+下划线，文件名全小写
-->
开发的时候注意到：
开启客户端后，如果监听到的第一条群消息就触发pickMember函数会无法正确的获得到群员对象，即使该群员存在于群聊中，感觉上有些小问题，于是尝试在群对象创建时就将群员列表缓存进client，问题得到解决，但不是很确定这样是否正确。