### PR TITLE
fix: 转发到群内的图文混合消息图片url 404

### DIFF
--- a/lib/message/parser.ts
+++ b/lib/message/parser.ts
@@ -318,7 +318,7 @@ export class Parser {
 			if (proto[29] && proto[29][30])
 				elem.url = `https://c2cpicdw.qpic.cn${proto[29][30]}&spec=0&rf=naio`
 			else if (proto[15])
-				elem.url = `https://c2cpicdw.qpic.cn${proto[15]}`
+				elem.url = getGroupImageUrl(proto[1].toString())
 			else if (proto[10])
 				elem.url = `https://c2cpicdw.qpic.cn/offpic_new/0/${proto[10]}/0`
 			if (elem.type === "image")


### PR DESCRIPTION
原始proto[15]用来判断什么的不太清楚，但是转发到群内的图文消息，根据原注释不会被识别为群图，导致图片url会生成404。