### PR TITLE
small fix: relative path for data_dir

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -135,7 +135,7 @@ export class Client extends BaseClient {
 		const dir = createDataDir(config.data_dir, uin)
 		const file = path.join(dir, `device-${uin}.json`)
 		try {
-			var device = require(file) as ShortDevice
+			var device = JSON.parse(fs.readFileSync(file)) as ShortDevice
 			var _ = false
 		} catch {
 			var device = generateShortDevice(uin)


### PR DESCRIPTION
client.ts uses "require()" for config loading and "fs.writeFile()" for writing. Two functions use different basepaths ("require()" searches files under the parent dir of the current .js file while another one uses cwd), so they may not be the same path. This may cause oicq to refresh user data every time it boots, since it cannot find the original config file.
