### PR TITLE
fix: PoW 算法错误

### DIFF
--- a/lib/core/base-client.ts
+++ b/lib/core/base-client.ts
@@ -938,14 +938,14 @@ function calcPoW(this: BaseClient, data: any) {
 	if (typ === 2 && tgt.length === 32) {
 		let tmp = BigInt("0x" + src.toString("hex"));
 		const start = Date.now()
-		let hash = createHash("sha256").update(Buffer.from(tmp.toString(16), "hex")).digest()
+		let hash = createHash("sha256").update(Buffer.from(tmp.toString(16).padStart(256, "0"), "hex")).digest()
 		while (Buffer.compare(hash, tgt)) {
 			tmp++
-			hash = createHash("sha256").update(Buffer.from(tmp.toString(16), "hex")).digest()
+			hash = createHash("sha256").update(Buffer.from(tmp.toString(16).padStart(256, "0"), "hex")).digest()
 			cnt++
 		}
 		ok = true
-		dst = Buffer.from(tmp.toString(16), "hex")
+		dst = Buffer.from(tmp.toString(16).padStart(256, "0"), "hex")
 		elp = Date.now() - start
 	}
 	const writer = new Writer()


### PR DESCRIPTION
当 src 的第一个字节为 00-09 时，开头的0在转换时可能会消失导致 Buffer 数据错位，遗漏数据，进而无法正确计算结果后进入死循环。